### PR TITLE
Update share message to include user's first attempt

### DIFF
--- a/src/create-word-comparison-sentence.ts
+++ b/src/create-word-comparison-sentence.ts
@@ -10,6 +10,8 @@ export const chatHistory: {
     text: string
 }[] = []
 
+export let firstTrial: string | null = null
+
 export async function createWordComparisonSentence(
     trial: string,
     answer: string = todaysWord
@@ -32,6 +34,10 @@ export async function createWordComparisonSentence(
         role: 'assistant',
         text: `${answer}는 ${trial}보다${sentence}`,
     })
+
+    if (firstTrial === null && !sentence.includes(answer)) {
+        firstTrial = `${trial}보다${sentence}`
+    }
 
     while (sentence.includes(answer)) {
         const leakedIndex = sentence.indexOf(answer)

--- a/src/show-finish-card.ts
+++ b/src/show-finish-card.ts
@@ -12,8 +12,7 @@ export function showFinishCard(trials: number) {
 
     const template = [
         `${todayString} #견주기 ${trials}번째 시도에 성공했습니다.`,
-        `첫 시도: ${chatHistory[1].text}`,
-        `초성이 ${todaysChosung}인 단어를 맞출 수 있을까요?`,
+        `초성이 ${todaysChosung}인 단어를 맞출 수 있을까요? ` + chatHistory[1].text,
         location.origin,
     ]
 

--- a/src/show-finish-card.ts
+++ b/src/show-finish-card.ts
@@ -1,5 +1,6 @@
 import { logWrapper } from './log'
 import { todaysChosung } from './todays-word'
+import { chatHistory } from './create-word-comparison-sentence'
 
 export function showFinishCard(trials: number) {
     const card = document.createElement('blockquote')
@@ -11,6 +12,7 @@ export function showFinishCard(trials: number) {
 
     const template = [
         `${todayString} #견주기 ${trials}번째 시도에 성공했습니다.`,
+        `첫 시도: ${chatHistory[1].text}`,
         `초성이 ${todaysChosung}인 단어를 맞출 수 있을까요?`,
         location.origin,
     ]

--- a/src/show-finish-card.ts
+++ b/src/show-finish-card.ts
@@ -1,6 +1,6 @@
 import { logWrapper } from './log'
 import { todaysChosung } from './todays-word'
-import { chatHistory } from './create-word-comparison-sentence'
+import { firstTrial } from './create-word-comparison-sentence'
 
 export function showFinishCard(trials: number) {
     const card = document.createElement('blockquote')
@@ -11,10 +11,10 @@ export function showFinishCard(trials: number) {
     const todayString = today.getMonth() + 1 + '월 ' + today.getDate() + '일'
 
     const template = [
-        `${todayString} #견주기 ${trials}번째 시도에 성공했습니다.`,
-        `초성이 ${todaysChosung}인 단어를 맞출 수 있을까요? ` + chatHistory[1].text,
+        `${todayString} #견주기 ${trials}번째 시도에 성공했습니다.\n초성이 ${todaysChosung}인 단어를 맞출 수 있을까요?`,
+        firstTrial,
         location.origin,
-    ]
+    ].filter(Boolean)
 
     p.innerHTML = template.join('<br>')
 


### PR DESCRIPTION
Add user's first attempt to the success message in the finish card.

* Import `chatHistory` from `create-word-comparison-sentence.ts` in `src/show-finish-card.ts`
* Update the `template` array in `showFinishCard` function to include the user's first attempt in the success message

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rycont/gyeon/pull/3?shareId=ab76c1cb-750b-4052-b640-cdf81c2eccea).